### PR TITLE
Rogomatic fixes for pc: message parsing, cursed weapons, vorpalized weapons, paralysis potions

### DIFF
--- a/src/Rogomatic/globals.h
+++ b/src/Rogomatic/globals.h
@@ -136,6 +136,7 @@ extern int poorarrow;		/* # Times we failed to kill in one blow */
 extern int protected;		/* True if we protected our armor */
 extern int putonseeinv;		/* Time when last put on see invisible ring */
 extern int quitat;		/* Score we are trying to beat */
+extern int read_vorpal;
 extern int redhands;		/* True if our hands are red */
 extern int replaying;		/* True if replaying old game */
 extern int revvideo;		/* True if in rev. video mode */

--- a/src/Rogomatic/io.c
+++ b/src/Rogomatic/io.c
@@ -221,7 +221,7 @@ int   onat;                             /* 0 ==> Wait for waitstr
     /* If message ends in "(* for list): ", call terpmes */
     if (ch == *q) {
         if (*++q == 0) {
-            if (pc_protocol()) //mdk: lines not getting cleared on pc. if previous message was longer, extra garbage would be present
+            if (pc_protocol()) //mdk: lines were not getting cleared on pc. if previous message was longer, extra garbage would be present
             {
                 for (int i = col; i < MAXCOLS; i++) {
                     screen[row][i] = ' ';

--- a/src/Rogomatic/io.c
+++ b/src/Rogomatic/io.c
@@ -221,7 +221,11 @@ int   onat;                             /* 0 ==> Wait for waitstr
     /* If message ends in "(* for list): ", call terpmes */
     if (ch == *q) {
         if (*++q == 0) {
-            if (pc_protocol()) //mdk: lines were not getting cleared on pc. if previous message was longer, extra garbage would be present
+            /*
+                mdk: Message line wasn't getting cleared on pc, leading to garbage like:
+                "wield what? (* for list): bow(weapon in hand) (c)"
+            */
+            if (pc_protocol())
             {
                 for (int i = col; i < MAXCOLS; i++) {
                     screen[row][i] = ' ';

--- a/src/Rogomatic/io.c
+++ b/src/Rogomatic/io.c
@@ -219,7 +219,17 @@ int   onat;                             /* 0 ==> Wait for waitstr
     }
 
     /* If message ends in "(* for list): ", call terpmes */
-    if (ch == *q) { if (*++q == 0) terpmes (); }
+    if (ch == *q) {
+        if (*++q == 0) {
+            if (pc_protocol)
+            {
+                for (int i = col; i < MAXCOLS; i++) {
+                    screen[row][i] = ' ';
+                }
+            }
+            terpmes();
+        }
+    }
     else q = "(* for list): ";
 
     /* Rogomatic now keys off of the grass under the Tombstone to  */

--- a/src/Rogomatic/io.c
+++ b/src/Rogomatic/io.c
@@ -221,7 +221,7 @@ int   onat;                             /* 0 ==> Wait for waitstr
     /* If message ends in "(* for list): ", call terpmes */
     if (ch == *q) {
         if (*++q == 0) {
-            if (pc_protocol)
+            if (pc_protocol()) //mdk: lines not getting cleared on pc. if previous message was longer, extra garbage would be present
             {
                 for (int i = col; i < MAXCOLS; i++) {
                     screen[row][i] = ' ';

--- a/src/Rogomatic/main.c
+++ b/src/Rogomatic/main.c
@@ -244,6 +244,7 @@ int   poorarrow = 0;		/* True if arrow has missed */
 int   protected = 0;		/* True if we protected our armor */
 int   putonseeinv = 0;          /* Turn when last put on see inv ring */
 int   quitat = BOGUS;		/* Score to beat, quit if within 10% more */
+int read_vorpal = 0;
 int   redhands = 0;		/* True if we have red hands */
 int   replaying = 0;		/* True if replaying old game */
 int   revvideo = 0;		/* True if in rev. video mode */

--- a/src/Rogomatic/mess.c
+++ b/src/Rogomatic/mess.c
@@ -152,6 +152,8 @@ void handle_vorpalize_flash()
 {
     if (is_reading_scroll())
     {
+        read_vorpal = 1;
+
         infer("vorpalize weapon", Scroll);
         newweapon = 1;
 
@@ -977,7 +979,11 @@ void curseditem ()
 
     /* Is it our weapon (may be wielding a hitter or a bogus magic arrow)? */
     else if (inven[lastdrop].type==hitter || inven[lastdrop].type==missile)
-      { currentweapon = lastdrop; cursedweapon = 1; return; }
+    {
+        currentweapon = lastdrop;
+        cursedweapon = 1;
+        return;
+    }
   }
 
   /* Don't know what was cursed, so assume the worst */

--- a/src/Rogomatic/pack.c
+++ b/src/Rogomatic/pack.c
@@ -325,9 +325,9 @@ char *msgstart, *msgend;
   if (*mend == '-')
     mend-=1;
 
-  if (mess[1] == ')')
+  if (mess[1] == ')') // handle format: a) item description
     { newitem = 1; ipos = DIGIT(*mess); mess += 3;}
-  else
+  else // handle format: item description (a)
     { ipos = DIGIT(mend[-2]); mend -= 4; }
 
 
@@ -344,7 +344,7 @@ char *msgstart, *msgend;
   }
 
   if (ISDIGIT(*mess))
-    { n = atoi(mess); mess += 2+(n>9); }
+    { n = atoi(mess); mess += 2+(n>9); } // get item quantity
   else {
     n = 1;
 
@@ -423,8 +423,16 @@ char *msgstart, *msgend;
 
   while (mend[-1] == ' ') mend--;
 
-  /* Undo plurals by removing trailing 's' (but not for "blindne->ss<-") */
-  if ((mend[-1]=='s') && (mend[-2] != 's')) mend--;
+  /* Undo plurals by removing trailing 's' (but not for "blindne->ss<-") mdk: or paralysis */
+  if ((mend[-1]=='s') && ((mend[-2] != 's') && (mend[-2] != 'i'))) mend--; //todo:mdk handle paralysis
+
+  static char weaponname[NAMSIZ], monstername[NAMSIZ], garbage[NAMSIZ];
+  static char* vorpalresult[] = { weaponname, monstername, garbage };
+  if (smatch(mess, "* of * slaying*", vorpalresult))
+  {
+      mess = weaponname;
+      mend = strlen(mess) + mess;
+  }
 
   /* Now find what we have picked up: */
   if (stlmatch(mend-4,"food")) {what=food; xknow=KNOWN;}
@@ -470,7 +478,8 @@ char *msgstart, *msgend;
   else if (stlmatch(mend-4,"dart")) xtr(missile,0,0,0)
   else if (stlmatch(mend-4,"rock")) xtr(missile,0,0,0)
   else if (stlmatch(mend-4,"bolt")) xtr(missile,0,0,0)
-  else xtr(strange,0,0,0)
+  else
+      xtr(strange,0,0,0)
 
   /* Copy the name of the object into a string */
   memset (objname, '\0', 100);
@@ -538,11 +547,12 @@ char *msgstart, *msgend;
     for (p = codename, q = codenamebeg; q <= codenameend;  p++, q++) *p = *q;
 
     if ((strlen (codename) > 2) &&
-      (strlen (findentry_getrealname (codename, what)) == 0)) {
+      (strlen (findentry_getrealname (codename, what)) == 0)) { //todo:mdk do we need to update db here?
       infername (codename, objname, what);
     }
   }
 
+  //todo:mdk newitem is always true?
   /* If new item, record the change */
   if (newitem && what == armor)
     newarmor = 1;

--- a/src/Rogomatic/pack.c
+++ b/src/Rogomatic/pack.c
@@ -479,7 +479,10 @@ char *msgstart, *msgend;
   else if (stlmatch(mend-4,"rock")) xtr(missile,0,0,0)
   else if (stlmatch(mend-4,"bolt")) xtr(missile,0,0,0)
   else
+  {
+      dwait (D_ERROR, "strange item in pack: %s", mess);
       xtr(strange,0,0,0)
+  }
 
   /* Copy the name of the object into a string */
   memset (objname, '\0', 100);

--- a/src/Rogomatic/pack.c
+++ b/src/Rogomatic/pack.c
@@ -552,7 +552,7 @@ char *msgstart, *msgend;
     }
   }
 
-  //todo:mdk newitem is always true?
+  //todo:mdk inventory is reset a lot, and newitem will always be true during a reset. things like lastfoodlevel are not accurate
   /* If new item, record the change */
   if (newitem && what == armor)
     newarmor = 1;

--- a/src/Rogomatic/pack.c
+++ b/src/Rogomatic/pack.c
@@ -424,7 +424,7 @@ char *msgstart, *msgend;
   while (mend[-1] == ' ') mend--;
 
   /* Undo plurals by removing trailing 's' (but not for "blindne->ss<-") mdk: or paralysis */
-  if ((mend[-1]=='s') && ((mend[-2] != 's') && (mend[-2] != 'i'))) mend--; //todo:mdk handle paralysis
+  if ((mend[-1]=='s') && ((mend[-2] != 's') && (mend[-2] != 'i'))) mend--;
 
   static char weaponname[NAMSIZ], monstername[NAMSIZ], garbage[NAMSIZ];
   static char* vorpalresult[] = { weaponname, monstername, garbage };

--- a/src/Rogomatic/rogomatic.h
+++ b/src/Rogomatic/rogomatic.h
@@ -381,3 +381,4 @@ int has_hidden_passages();
 int pc_protocol();
 int vorpalize_weapon_can_be_cursed();
 int is_reading_scroll();
+int enable_bugfixes();

--- a/src/Rogomatic/things.c
+++ b/src/Rogomatic/things.c
@@ -92,7 +92,8 @@ int obj;
       cursedweapon=0;
       command (T_HANDLING, "w%c", LETTER (obj));
     }
-    else if (itemis(currentweapon, ENCHANTED)) {
+    else if (itemis(currentweapon, ENCHANTED)
+        && (!vorpalize_weapon_can_be_cursed() || !read_vorpal)) { //mdk: vorpalized weapon is enchanted but can be cursed
       remember(currentweapon, UNCURSED);
       cursedweapon=0;
       command (T_HANDLING, "w%c", LETTER (obj));
@@ -112,7 +113,7 @@ int obj;
    * momentatirily on the first escape
    */
   else
-    command (T_HANDLING, "w%cw%c%c", LETTER (obj), ESC, get_repeat_message_key());
+    command (T_HANDLING, "w%cw%c%c", LETTER (obj), ESC, get_repeat_message_key()); /* mdk: this was causing pc rogue to hang. "wc" when weapon cursed would cause "c" to be treated as a command and trigger a more loop */
 
   return (1);
 }
@@ -619,7 +620,7 @@ int haveuseless ()
          stlmatch (inven[i].str, "poison") ||
          stlmatch (inven[i].str, "confusion") ||
          stlmatch (inven[i].str, "magic detection") ||
-         stlmatch (inven[i].str, "paralysis") ||
+         (enable_bugfixes() && stlmatch (inven[i].str, "paralysis")) || //mdk: this code didn't used to get hit, since item was "paralysi" in inventory
          stlmatch (inven[i].str, "hallucination") ||
          stlmatch (inven[i].str, "thirst") ||
          stlmatch (inven[i].str, "food detection") ||

--- a/src/Rogomatic/versions.c
+++ b/src/Rogomatic/versions.c
@@ -1,5 +1,10 @@
 #include "globals.h"
 
+int is_pc_version()
+{
+    return version == RVPC11 || version == RVPC148;
+}
+
 int version_has_arrow_bug()
 {
     return version <= RV36B;
@@ -82,7 +87,7 @@ else
 
 int new_weapon_protocol()
 {
-    return version >= RV54A;
+    return version >= RV54A || is_pc_version();
 }
 
 int dynamic_inv_order()
@@ -109,7 +114,7 @@ int status_v2()
 
 int status_v3()
 {
-    return version == RVPC11 || version == RVPC148;
+    return is_pc_version();
 }
 
 int version_uses_new_strength()
@@ -149,7 +154,7 @@ int has_hidden_passages()
 
 int pc_protocol()
 {
-    return version == RVPC11 || version == RVPC148;
+    return is_pc_version();
 }
 
 int eat_after_fainting()
@@ -160,4 +165,9 @@ int eat_after_fainting()
 int vorpalize_weapon_can_be_cursed()
 {
     return version == RVPC11;
+}
+
+int enable_bugfixes()
+{
+    return 0; //todo:mdk these are disabled so old replays still work. i should add a new gene that acts like a bitset of feature flags
 }

--- a/src/Rogomatic/worth.c
+++ b/src/Rogomatic/worth.c
@@ -167,7 +167,7 @@ int i;
 
   /* Many potions are useless */
   if (inven[i].type == potion && itemis (i, KNOWN) &&
-      (stlmatch (inven[i].str, "paralysi") || //todo:mdk typo. should i fix?
+      (stlmatch (inven[i].str, "paralysis") ||
        stlmatch (inven[i].str, "confusion") ||
        stlmatch (inven[i].str, "hallucination") ||
        stlmatch (inven[i].str, "blind") ||


### PR DESCRIPTION
- Fix issue with corrupt message getting passed to `terpmes`
- Allow a vorpalized weapon with a known target monster to be parsed in `inventory`
  - The monster name is extracted out, but no action is taken with it yet
  - For #37
- Fix corruption with potion of paralysis (it was being stored as "paralysi", so some logic wasn't working)
- Use new weapon protocol for PC versions to avoid more loops with a cursed weapon
- Treat strange things in inventory as an error